### PR TITLE
Be/feature/auth

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 
     implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
     implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
 }
 
 test {

--- a/BE/src/main/java/com/codesquad/sidedish08/config/AuthProperties.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/config/AuthProperties.java
@@ -1,0 +1,23 @@
+package com.codesquad.sidedish08.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "auth")
+public class AuthProperties {
+
+  @Value("${auth.client-id}")
+  private String clientId;
+  @Value("${auth.client-secret}")
+  private String clientSecret;
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+}

--- a/BE/src/main/java/com/codesquad/sidedish08/config/JwtProperties.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/config/JwtProperties.java
@@ -1,0 +1,17 @@
+package com.codesquad.sidedish08.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+  @Value("${jwt.salt}")
+  private String salt;
+
+  public String getSalt() {
+    return salt;
+  }
+}

--- a/BE/src/main/java/com/codesquad/sidedish08/controller/AuthController.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/controller/AuthController.java
@@ -1,13 +1,16 @@
 package com.codesquad.sidedish08.controller;
 
+import static com.codesquad.sidedish08.util.ResponseUtils.getResultMap;
+
 import com.codesquad.sidedish08.message.AuthMessages;
+import com.codesquad.sidedish08.message.SuccessMessages;
+import com.codesquad.sidedish08.model.response.ApiResponse;
 import com.codesquad.sidedish08.service.AuthService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import javax.websocket.server.PathParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,9 +36,10 @@ public class AuthController {
 
   @ApiOperation(value = "", notes = AuthMessages.CALLBACK)
   @GetMapping("/callback")
-  public HttpEntity<String> callback(@PathParam("code") String code) {
+  public ApiResponse callback(@PathParam("code") String code) {
     log.debug("### code : {}", code);
 
-    return authService.callback(code);
+    return ApiResponse.ok(
+        SuccessMessages.SUCCESS, getResultMap("body", authService.callback(code)));
   }
 }

--- a/BE/src/main/java/com/codesquad/sidedish08/controller/AuthController.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/controller/AuthController.java
@@ -37,8 +37,6 @@ public class AuthController {
   @ApiOperation(value = "", notes = AuthMessages.CALLBACK)
   @GetMapping("/callback")
   public ApiResponse callback(@PathParam("code") String code) {
-    log.debug("### code : {}", code);
-
     return ApiResponse.ok(
         SuccessMessages.SUCCESS, getResultMap("body", authService.callback(code)));
   }

--- a/BE/src/main/java/com/codesquad/sidedish08/controller/AuthController.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/controller/AuthController.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiOperation;
 import javax.websocket.server.PathParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,7 +33,7 @@ public class AuthController {
 
   @ApiOperation(value = "", notes = AuthMessages.CALLBACK)
   @GetMapping("/callback")
-  public Object callback(@PathParam("code") String code) {
+  public HttpEntity<String> callback(@PathParam("code") String code) {
     log.debug("### code : {}", code);
 
     return authService.callback(code);

--- a/BE/src/main/java/com/codesquad/sidedish08/controller/AuthController.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/controller/AuthController.java
@@ -1,11 +1,13 @@
 package com.codesquad.sidedish08.controller;
 
 import com.codesquad.sidedish08.message.AuthMessages;
-import com.codesquad.sidedish08.message.SuccessMessages;
-import com.codesquad.sidedish08.model.response.ApiResponse;
 import com.codesquad.sidedish08.service.AuthService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import javax.websocket.server.PathParam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 public class AuthController {
 
+  private static final Logger log = LoggerFactory.getLogger(AuthController.class);
   private final AuthService authService;
 
   public AuthController(AuthService authService) {
@@ -22,8 +25,16 @@ public class AuthController {
   }
 
   @ApiOperation(value = "", notes = AuthMessages.LOGIN)
-  @GetMapping("login")
-  public ApiResponse login() {
-    return ApiResponse.ok(SuccessMessages.SUCCESS, authService.login());
+  @GetMapping("/login")
+  public ResponseEntity<String> login() {
+    return authService.login();
+  }
+
+  @ApiOperation(value = "", notes = AuthMessages.CALLBACK)
+  @GetMapping("/callback")
+  public Object callback(@PathParam("code") String code) {
+    log.debug("### code : {}", code);
+
+    return authService.callback(code);
   }
 }

--- a/BE/src/main/java/com/codesquad/sidedish08/message/AuthMessages.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/message/AuthMessages.java
@@ -9,9 +9,5 @@ public class AuthMessages {
   public static final String ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
   public static final String USER_EMAIL_URL = "https://api.github.com/user/emails";
 
-  public static final String CLIENT_ID = "31ae5169a7dc37e19605";
-  public static final String CLIENT_SECRET = "43debfbf5b584d5a0c7b58d215c5462a29ecd5e1";
-
-  public static final String SALT = "sidedish08SecreatKey";
   public static final Long EXPIRED_TIME = 1000L * 60L * 30L;
 }

--- a/BE/src/main/java/com/codesquad/sidedish08/message/AuthMessages.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/message/AuthMessages.java
@@ -10,4 +10,5 @@ public class AuthMessages {
   public static final String USER_EMAIL = "https://api.github.com/user/emails";
   public static final String CLIENT_ID = "31ae5169a7dc37e19605";
   public static final String CLIENT_SECRET = "43debfbf5b584d5a0c7b58d215c5462a29ecd5e1";
+  public static final String SALT = "sidedish08SecreatKey";
 }

--- a/BE/src/main/java/com/codesquad/sidedish08/message/AuthMessages.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/message/AuthMessages.java
@@ -7,8 +7,11 @@ public class AuthMessages {
 
   public static final String AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
   public static final String ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
-  public static final String USER_EMAIL = "https://api.github.com/user/emails";
+  public static final String USER_EMAIL_URL = "https://api.github.com/user/emails";
+
   public static final String CLIENT_ID = "31ae5169a7dc37e19605";
   public static final String CLIENT_SECRET = "43debfbf5b584d5a0c7b58d215c5462a29ecd5e1";
+
   public static final String SALT = "sidedish08SecreatKey";
+  public static final Long EXPIRED_TIME = 1000L * 60L * 30L;
 }

--- a/BE/src/main/java/com/codesquad/sidedish08/message/AuthMessages.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/message/AuthMessages.java
@@ -3,4 +3,11 @@ package com.codesquad.sidedish08.message;
 public class AuthMessages {
 
   public static final String LOGIN = "Github 로그인";
+  public static final String CALLBACK = "Github CallBack";
+
+  public static final String AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
+  public static final String ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+  public static final String USER_EMAIL = "https://api.github.com/user/emails";
+  public static final String CLIENT_ID = "31ae5169a7dc37e19605";
+  public static final String CLIENT_SECRET = "43debfbf5b584d5a0c7b58d215c5462a29ecd5e1";
 }

--- a/BE/src/main/java/com/codesquad/sidedish08/message/ErrorMessages.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/message/ErrorMessages.java
@@ -4,4 +4,5 @@ public class ErrorMessages {
 
   public static final String ERROR = "ERROR";
   public static final String NO_SUCH_ELEMENT_EXCEPTION = "요청 값의 객체를 찾을 수 없습니다";
+  public static final String FAILED_MAKE_JWT = "JWT TOKEN 생성에 실패하였습니다";
 }

--- a/BE/src/main/java/com/codesquad/sidedish08/service/AuthService.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/service/AuthService.java
@@ -2,10 +2,9 @@ package com.codesquad.sidedish08.service;
 
 import static com.codesquad.sidedish08.message.AuthMessages.ACCESS_TOKEN_URL;
 import static com.codesquad.sidedish08.message.AuthMessages.AUTHORIZE_URL;
-import static com.codesquad.sidedish08.message.AuthMessages.CLIENT_ID;
-import static com.codesquad.sidedish08.message.AuthMessages.CLIENT_SECRET;
 import static com.codesquad.sidedish08.message.AuthMessages.USER_EMAIL_URL;
 
+import com.codesquad.sidedish08.config.AuthProperties;
 import com.codesquad.sidedish08.message.ErrorMessages;
 import com.codesquad.sidedish08.util.TokenUtil;
 import java.nio.charset.StandardCharsets;
@@ -32,6 +31,11 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class AuthService {
 
   private static final Logger log = LoggerFactory.getLogger(AuthService.class);
+  private final AuthProperties authProperties;
+
+  public AuthService(AuthProperties authProperties) {
+    this.authProperties = authProperties;
+  }
 
   public ResponseEntity<String> login() {
     HttpHeaders headers = new HttpHeaders();
@@ -40,7 +44,7 @@ public class AuthService {
 
     UriComponents builder = UriComponentsBuilder
         .fromHttpUrl(AUTHORIZE_URL)
-        .queryParam("client_id", CLIENT_ID)
+        .queryParam("client_id", authProperties.getClientId())
         .queryParam("scope", "user")
         .build(false);
 
@@ -63,8 +67,8 @@ public class AuthService {
 
     MultiValueMap<String, String> requestPayloads = new LinkedMultiValueMap<>();
     Map<String, String> requestPayload = new HashMap<>();
-    requestPayload.put("client_id", CLIENT_ID);
-    requestPayload.put("client_secret", CLIENT_SECRET);
+    requestPayload.put("client_id", authProperties.getClientId());
+    requestPayload.put("client_secret", authProperties.getClientSecret());
     requestPayload.put("code", authorizationCode);
     requestPayloads.setAll(requestPayload);
 

--- a/BE/src/main/java/com/codesquad/sidedish08/service/AuthService.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/service/AuthService.java
@@ -48,7 +48,13 @@ public class AuthService {
         builder.toUriString(), HttpMethod.GET, new HttpEntity<String>(headers), String.class);
   }
 
-  public String callback(String code) {
+  public String callback(String authorizationCode) {
+    String accessToken = getAccessToken(authorizationCode);
+    List<LinkedHashMap<String, String>> emails = getEmails(accessToken);
+    return TokenUtil.create(emails.get(0));
+  }
+
+  private String getAccessToken(String authorizationCode) {
     MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
     Map<String, String> header = new HashMap<>();
     header.put("Accept", "application/json");
@@ -58,7 +64,7 @@ public class AuthService {
     Map<String, String> requestPayload = new HashMap<>();
     requestPayload.put("client_id", CLIENT_ID);
     requestPayload.put("client_secret", CLIENT_SECRET);
-    requestPayload.put("code", code);
+    requestPayload.put("code", authorizationCode);
     requestPayloads.setAll(requestPayload);
 
     HttpEntity<?> request = new HttpEntity<>(requestPayloads, headers);
@@ -66,17 +72,7 @@ public class AuthService {
         .postForEntity(ACCESS_TOKEN_URL, request, HashMap.class);
 
     Map<String, String> map = (Map<String, String>) response.getBody();
-    String accessToken = map.get("access_token");
-
-    Map<String, String> claims = new HashMap<>();
-//    claims.put("email", getEmails(accessToken));
-
-    log.debug("##### email : {}", getEmails(accessToken));
-
-    List<LinkedHashMap<String, String>> emails = getEmails(accessToken);
-
-    String token = TokenUtil.create(emails.get(0));
-    return token;
+    return map.get("access_token");
   }
 
   private List<LinkedHashMap<String, String>> getEmails(String accessToken) {

--- a/BE/src/main/java/com/codesquad/sidedish08/service/AuthService.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/service/AuthService.java
@@ -45,10 +45,10 @@ public class AuthService {
         builder.toUriString(), HttpMethod.GET, new HttpEntity<String>(headers), String.class);
   }
 
-  public Object callback(String code) {
+  public HttpEntity<String> callback(String code) {
     MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
     Map<String, String> header = new HashMap<>();
-    header.put("Accept", "application/json"); //json 형식으로 응답 받음
+    header.put("Accept", "application/json");
     headers.setAll(header);
 
     MultiValueMap<String, String> requestPayloads = new LinkedMultiValueMap<>();
@@ -62,19 +62,20 @@ public class AuthService {
     ResponseEntity<?> response = new RestTemplate()
         .postForEntity(ACCESS_TOKEN_URL, request, HashMap.class);
 
-    log.debug("### response.getBody().getClass() : {}", response.getBody().getClass());
     Map<String, String> map = (Map<String, String>) response.getBody();
     String accessToken = map.get("access_token");
 
     return getEmails(accessToken);
   }
 
-  private Object getEmails(String accessToken) {
+  private HttpEntity<String> getEmails(String accessToken) {
     RestTemplate restTemplate = new RestTemplate();
+
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(
         new MediaType("application", "json", StandardCharsets.UTF_8));
     headers.add("Authorization", "bearer " + accessToken);
+
     UriComponents builder = UriComponentsBuilder
         .fromHttpUrl(USER_EMAIL)
         .build(false);

--- a/BE/src/main/java/com/codesquad/sidedish08/service/AuthService.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/service/AuthService.java
@@ -4,7 +4,7 @@ import static com.codesquad.sidedish08.message.AuthMessages.ACCESS_TOKEN_URL;
 import static com.codesquad.sidedish08.message.AuthMessages.AUTHORIZE_URL;
 import static com.codesquad.sidedish08.message.AuthMessages.CLIENT_ID;
 import static com.codesquad.sidedish08.message.AuthMessages.CLIENT_SECRET;
-import static com.codesquad.sidedish08.message.AuthMessages.USER_EMAIL;
+import static com.codesquad.sidedish08.message.AuthMessages.USER_EMAIL_URL;
 
 import com.codesquad.sidedish08.message.ErrorMessages;
 import com.codesquad.sidedish08.util.TokenUtil;
@@ -85,7 +85,7 @@ public class AuthService {
     headers.add("Authorization", "bearer " + accessToken);
 
     ResponseEntity<List> response = new RestTemplate().exchange(
-        USER_EMAIL, HttpMethod.GET, new HttpEntity<String>(headers), List.class);
+        USER_EMAIL_URL, HttpMethod.GET, new HttpEntity<String>(headers), List.class);
 
     return response.getBody();
   }

--- a/BE/src/main/java/com/codesquad/sidedish08/service/AuthService.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/service/AuthService.java
@@ -1,12 +1,85 @@
 package com.codesquad.sidedish08.service;
 
+import static com.codesquad.sidedish08.message.AuthMessages.ACCESS_TOKEN_URL;
+import static com.codesquad.sidedish08.message.AuthMessages.AUTHORIZE_URL;
+import static com.codesquad.sidedish08.message.AuthMessages.CLIENT_ID;
+import static com.codesquad.sidedish08.message.AuthMessages.CLIENT_SECRET;
+import static com.codesquad.sidedish08.message.AuthMessages.USER_EMAIL;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 public class AuthService {
 
-  public Map<String, ?> login() {
-    return null;
+  private static final Logger log = LoggerFactory.getLogger(AuthService.class);
+
+  public ResponseEntity<String> login() {
+    RestTemplate restTemplate = new RestTemplate();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(
+        new MediaType("application", "json", StandardCharsets.UTF_8));
+
+    UriComponents builder = UriComponentsBuilder
+        .fromHttpUrl(AUTHORIZE_URL)
+        .queryParam("client_id", CLIENT_ID)
+        .queryParam("scope", "user")
+        .build(false);
+
+    return restTemplate.exchange(
+        builder.toUriString(), HttpMethod.GET, new HttpEntity<String>(headers), String.class);
+  }
+
+  public Object callback(String code) {
+    MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+    Map<String, String> header = new HashMap<>();
+    header.put("Accept", "application/json"); //json 형식으로 응답 받음
+    headers.setAll(header);
+
+    MultiValueMap<String, String> requestPayloads = new LinkedMultiValueMap<>();
+    Map<String, String> requestPayload = new HashMap<>();
+    requestPayload.put("client_id", CLIENT_ID);
+    requestPayload.put("client_secret", CLIENT_SECRET);
+    requestPayload.put("code", code);
+    requestPayloads.setAll(requestPayload);
+
+    HttpEntity<?> request = new HttpEntity<>(requestPayloads, headers);
+    ResponseEntity<?> response = new RestTemplate()
+        .postForEntity(ACCESS_TOKEN_URL, request, HashMap.class);
+
+    log.debug("### response.getBody().getClass() : {}", response.getBody().getClass());
+    Map<String, String> map = (Map<String, String>) response.getBody();
+    String accessToken = map.get("access_token");
+
+    return getEmails(accessToken);
+  }
+
+  private Object getEmails(String accessToken) {
+    RestTemplate restTemplate = new RestTemplate();
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(
+        new MediaType("application", "json", StandardCharsets.UTF_8));
+    headers.add("Authorization", "bearer " + accessToken);
+    UriComponents builder = UriComponentsBuilder
+        .fromHttpUrl(USER_EMAIL)
+        .build(false);
+
+    return restTemplate.exchange(
+        builder.toUriString(), HttpMethod.GET, new HttpEntity<String>(headers), String.class);
   }
 }

--- a/BE/src/main/java/com/codesquad/sidedish08/service/AuthService.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/service/AuthService.java
@@ -6,8 +6,11 @@ import static com.codesquad.sidedish08.message.AuthMessages.CLIENT_ID;
 import static com.codesquad.sidedish08.message.AuthMessages.CLIENT_SECRET;
 import static com.codesquad.sidedish08.message.AuthMessages.USER_EMAIL;
 
+import com.codesquad.sidedish08.util.TokenUtil;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +48,7 @@ public class AuthService {
         builder.toUriString(), HttpMethod.GET, new HttpEntity<String>(headers), String.class);
   }
 
-  public HttpEntity<String> callback(String code) {
+  public String callback(String code) {
     MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
     Map<String, String> header = new HashMap<>();
     header.put("Accept", "application/json");
@@ -65,10 +68,18 @@ public class AuthService {
     Map<String, String> map = (Map<String, String>) response.getBody();
     String accessToken = map.get("access_token");
 
-    return getEmails(accessToken);
+    Map<String, String> claims = new HashMap<>();
+//    claims.put("email", getEmails(accessToken));
+
+    log.debug("##### email : {}", getEmails(accessToken));
+
+    List<LinkedHashMap<String, String>> emails = getEmails(accessToken);
+
+    String token = TokenUtil.create(emails.get(0));
+    return token;
   }
 
-  private HttpEntity<String> getEmails(String accessToken) {
+  private List<LinkedHashMap<String, String>> getEmails(String accessToken) {
     RestTemplate restTemplate = new RestTemplate();
 
     HttpHeaders headers = new HttpHeaders();
@@ -80,7 +91,9 @@ public class AuthService {
         .fromHttpUrl(USER_EMAIL)
         .build(false);
 
-    return restTemplate.exchange(
-        builder.toUriString(), HttpMethod.GET, new HttpEntity<String>(headers), String.class);
+    ResponseEntity<List> response = restTemplate.exchange(
+        builder.toUriString(), HttpMethod.GET, new HttpEntity<String>(headers), List.class);
+
+    return response.getBody();
   }
 }

--- a/BE/src/main/java/com/codesquad/sidedish08/util/TokenUtil.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/util/TokenUtil.java
@@ -3,7 +3,7 @@ package com.codesquad.sidedish08.util;
 
 import static com.codesquad.sidedish08.message.AuthMessages.EXPIRED_TIME;
 
-import com.codesquad.sidedish08.message.AuthMessages;
+import com.codesquad.sidedish08.config.JwtProperties;
 import com.codesquad.sidedish08.message.ErrorMessages;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
@@ -20,8 +20,7 @@ public class TokenUtil {
           .setHeaderParam("typ", "JWT")
           .setIssuer("Dan")
           .setIssuedAt(new Date(System.currentTimeMillis()))
-          .setExpiration(new Date(System.currentTimeMillis() + EXPIRED_TIME))
-          .setSubject("loginToken");
+          .setExpiration(new Date(System.currentTimeMillis() + EXPIRED_TIME));
       for (String key : claims.keySet()) {
         jwt.claim(key, claims.get(key));
       }
@@ -33,6 +32,6 @@ public class TokenUtil {
   }
 
   private static byte[] generateKey() {
-    return AuthMessages.SALT.getBytes(StandardCharsets.UTF_8);
+    return new JwtProperties().getSalt().getBytes(StandardCharsets.UTF_8);
   }
 }

--- a/BE/src/main/java/com/codesquad/sidedish08/util/TokenUtil.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/util/TokenUtil.java
@@ -1,10 +1,10 @@
 package com.codesquad.sidedish08.util;
 
 
+import static com.codesquad.sidedish08.message.AuthMessages.EXPIRED_TIME;
+
 import com.codesquad.sidedish08.message.AuthMessages;
 import com.codesquad.sidedish08.message.ErrorMessages;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -14,50 +14,21 @@ import java.util.Map;
 
 public class TokenUtil {
 
-  public static final Long EXPIRED_TIME = 1000L * 60L * 30L;
-
   public static String create(Map<String, String> claims) {
     try {
-
       JwtBuilder jwt = Jwts.builder()
           .setHeaderParam("typ", "JWT")
           .setIssuer("Dan")
           .setIssuedAt(new Date(System.currentTimeMillis()))
           .setExpiration(new Date(System.currentTimeMillis() + EXPIRED_TIME))
           .setSubject("loginToken");
-
       for (String key : claims.keySet()) {
         jwt.claim(key, claims.get(key));
       }
 
-      return jwt.signWith(SignatureAlgorithm.HS256, generateKey())
-          .compact();
+      return jwt.signWith(SignatureAlgorithm.HS256, generateKey()).compact();
     } catch (Exception e) {
       throw new RuntimeException(ErrorMessages.FAILED_MAKE_JWT);
-    }
-  }
-
-  public static boolean verify(String token) {
-    try {
-      Jws<Claims> claims = Jwts.parser()
-          .setSigningKey(generateKey())
-          .parseClaimsJws(token);
-      return true;
-    } catch (Exception e) {
-      return false;
-    }
-  }
-
-  public static String getUserId(String token) {
-    try {
-      return Jwts.parser()
-          .setSigningKey(generateKey())
-          .parseClaimsJws(token)
-          .getBody().get("userId")
-          .toString();
-    } catch (Exception e) {
-      //      throw new UnauthorizedException();
-      return "anonymous";
     }
   }
 

--- a/BE/src/main/java/com/codesquad/sidedish08/util/TokenUtil.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/util/TokenUtil.java
@@ -4,6 +4,7 @@ package com.codesquad.sidedish08.util;
 import static com.codesquad.sidedish08.message.AuthMessages.EXPIRED_TIME;
 
 import com.codesquad.sidedish08.config.JwtProperties;
+import com.codesquad.sidedish08.controller.AuthController;
 import com.codesquad.sidedish08.message.ErrorMessages;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
@@ -11,8 +12,21 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
+import javax.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
+@Component
 public class TokenUtil {
+
+  private static final Logger log = LoggerFactory.getLogger(AuthController.class);
+  private static JwtProperties staticJwtProperties;
+  private final JwtProperties jwtProperties;
+
+  public TokenUtil(JwtProperties jwtProperties) {
+    this.jwtProperties = jwtProperties;
+  }
 
   public static String create(Map<String, String> claims) {
     try {
@@ -32,6 +46,11 @@ public class TokenUtil {
   }
 
   private static byte[] generateKey() {
-    return new JwtProperties().getSalt().getBytes(StandardCharsets.UTF_8);
+    return staticJwtProperties.getSalt().getBytes(StandardCharsets.UTF_8);
+  }
+
+  @PostConstruct
+  private void initStaticJwtProperties() {
+    staticJwtProperties = this.jwtProperties;
   }
 }

--- a/BE/src/main/java/com/codesquad/sidedish08/util/TokenUtil.java
+++ b/BE/src/main/java/com/codesquad/sidedish08/util/TokenUtil.java
@@ -1,0 +1,67 @@
+package com.codesquad.sidedish08.util;
+
+
+import com.codesquad.sidedish08.message.AuthMessages;
+import com.codesquad.sidedish08.message.ErrorMessages;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Map;
+
+public class TokenUtil {
+
+  public static final Long EXPIRED_TIME = 1000L * 60L * 30L;
+
+  public static String create(Map<String, String> claims) {
+    try {
+
+      JwtBuilder jwt = Jwts.builder()
+          .setHeaderParam("typ", "JWT")
+          .setIssuer("Dan")
+          .setIssuedAt(new Date(System.currentTimeMillis()))
+          .setExpiration(new Date(System.currentTimeMillis() + EXPIRED_TIME))
+          .setSubject("loginToken");
+
+      for (String key : claims.keySet()) {
+        jwt.claim(key, claims.get(key));
+      }
+
+      return jwt.signWith(SignatureAlgorithm.HS256, generateKey())
+          .compact();
+    } catch (Exception e) {
+      throw new RuntimeException(ErrorMessages.FAILED_MAKE_JWT);
+    }
+  }
+
+  public static boolean verify(String token) {
+    try {
+      Jws<Claims> claims = Jwts.parser()
+          .setSigningKey(generateKey())
+          .parseClaimsJws(token);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  public static String getUserId(String token) {
+    try {
+      return Jwts.parser()
+          .setSigningKey(generateKey())
+          .parseClaimsJws(token)
+          .getBody().get("userId")
+          .toString();
+    } catch (Exception e) {
+      //      throw new UnauthorizedException();
+      return "anonymous";
+    }
+  }
+
+  private static byte[] generateKey() {
+    return AuthMessages.SALT.getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -12,14 +12,6 @@ logging:
     console: "%d{dd-MM-yyyy HH:mm:ss.SSS,Asia/Seoul} %magenta([%thread]) %highlight(%-5level) %logger.%M - %msg%n"
   file:
     name: logs/dev_log.log
-
-auth:
-  client-id: 31ae5169a7dc37e19605
-  client-secret: 43debfbf5b584d5a0c7b58d215c5462a29ecd5e1
-
-jwt:
-  salt: sidedish08SecreatKey
-
 ---
 spring:
   profiles: dev
@@ -31,6 +23,11 @@ spring:
   h2:
     console:
       enabled: true
+auth:
+  client-id: 31ae5169a7dc37e19605
+  client-secret: 43debfbf5b584d5a0c7b58d215c5462a29ecd5e1
+jwt:
+  salt: sidedish08SecreatKey
 ---
 spring:
   profiles: prod

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: dev
+    active: prod
 
 # logging 설정
 logging:
@@ -41,3 +41,8 @@ spring:
     initialization-mode: always
     hikari:
       maximum-pool-size: 10
+auth:
+  client-id: 2807fe374c60994c1363
+  client-secret: 62a3b5b1616f5982f56c3a0eb4f7f9bac54081f3
+jwt:
+  salt: sidedish08SecreatKey

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -13,15 +13,21 @@ logging:
   file:
     name: logs/dev_log.log
 
+auth:
+  client-id: 31ae5169a7dc37e19605
+  client-secret: 43debfbf5b584d5a0c7b58d215c5462a29ecd5e1
+
+jwt:
+  salt: sidedish08SecreatKey
+
 ---
 spring:
   profiles: dev
   datasource:
-    hikari:
-      jdbc-url: jdbc:h2:mem://localhost/sidedish_db;
-      driver-class-name: org.h2.Driver
-      username: sa
-      password:
+    driverClassName: org.h2.Driver
+    url: jdbc:h2:mem://localhost/sidedish_db;
+    username: sa
+    password:
   h2:
     console:
       enabled: true


### PR DESCRIPTION
- 현재 들어가 있는 client_id, secreat 는 제 github 의 것이지만 local 테스트에 문제가 없도록 환경변수화 하였습니다

- FE/iOS 에서는 login 으로만 접근하면 이후 처리는 자동으로 되고, jwt 형태로 email 을 응답합니다

- 로그인이 되지 않아도 배민찬 페이지는 보이게 하는 것이 좋다고 보이며, jwt 토큰의 이메일 주소를 통해 로그인 여부만 표시하면 될듯 합니다

- yml profile 를 통해 client_id, secreat 를 뺏고, 외부 변수화 또는 암호화는 좀 더 생각해봐야겠습니다

---

- [x] AuthController
  - [x] login
  - [x] callback
- [x] AuthService
  - [x] login
    - User 가 권한을 승인하도록 github 의 response 를 받아옴
  - [x] callback
    - getAccessToken 와 getEmails 를 통해 jwt 토큰을 만듬
  - [x] getAccessToken
    - rediect 된 authnization_code 를 통해 access_token 을 받아옴
  - [x] getEmails
    - access_token 을 통해 email 을 가져옴
- [x] TokenUtil
  - make jwt token
- [x] 민감정보 분리
  - yml 에 옮기고 prod, dev 가 바라보는 clinet 정보도 분리